### PR TITLE
Fix overflow of platform name

### DIFF
--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -107,6 +107,7 @@ $breakpoints: (
     font-weight: 600;
     letter-spacing: 0.11px;
     line-height: rem(18px);
+    white-space: nowrap;
   }
 
   .#{$prefix}--bmrg-header-brand__text {


### PR DESCRIPTION
## Context

Fix overflow of platform name on smaller viewports 

Jira Issue:

N/A

Build Number:

N/A

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If an item is not relevant to your change, you can put down "N/A" -->

- [ ] Has been verified in an integrated environment
- [ ] Has relevant unit and integration tests passing
- [ ] Has no linting, test console, or browser console errors (best effort)
- [ ] Has JSDoc comment blocks for complex code

## PR Review Guidance
goes from this
![image](https://user-images.githubusercontent.com/4127669/150013831-ea344fe5-c4cd-4f8f-9b73-b38840fe27ef.png)

to

![image](https://user-images.githubusercontent.com/4127669/150013862-d885a301-435f-4674-8a45-a13116bd7094.png)



## Additional Info

We don't support mobile but I do think we should at least make sure the header renders well if a user does access it from a mobile device or they simply make the window smaller. The overflow looks bad imo. 
