### PR TITLE
Fix platform notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ package-lock.json
 .npmrc
 results
 
+.env
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/carbon-addons-boomerang-react",
   "description": "Carbon Addons for Boomerang apps",
-  "version": "2.0.0",
+  "version": "2.0.1-rc.0",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/src/components/PlatformNotifications/PlatformNotifications.js
+++ b/src/components/PlatformNotifications/PlatformNotifications.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cx from 'classnames';
 import { Close16 } from '@carbon/icons-react';
-import { formatDistance, format } from 'date-fns';
+import { formatDistance, format, parseISO } from 'date-fns';
 import { settings } from 'carbon-components';
 
 const { prefix } = settings;
@@ -28,7 +28,7 @@ function Notification({ readNotification, notificationInfo }) {
         <p className={`${prefix}--bmrg-notification-content__desc`}>{notificationInfo.detail}</p>
         <time className={`${prefix}--bmrg-notification-content__date`}>
           {`${formatDistance(new Date(notificationInfo.date), new Date())} ago at ${format(
-            notificationInfo.date,
+            parseISO(notificationInfo.date),
             'hh:mma'
           )}`}
         </time>
@@ -47,7 +47,7 @@ Notification.propTypes = {
   readNotification: PropTypes.func,
   notificationInfo: PropTypes.shape({
     creator: PropTypes.string,
-    date: PropTypes.number,
+    date: PropTypes.string,
     detail: PropTypes.string,
     id: PropTypes.string,
     location: PropTypes.string,

--- a/src/components/PlatformNotifications/PlatformNotifications.spec.js
+++ b/src/components/PlatformNotifications/PlatformNotifications.spec.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import PlatformNotifications from './PlatformNotifications';
+import { screen, render } from '@testing-library/react';
+
+const notificationsObj = {
+  creator: 'Boomerang CICD',
+  date: '2022-03-15T12:47:47.655+00:00',
+  detail: 'Outage description test for the following service(s): Boomerang Flow,Boomerang CICD',
+  eventId: '620b9f7e99fcb715cbc222b3',
+  id: '620ba0f354f1b83f5077dec6',
+  priority: 'highest',
+  read: false,
+  severity: 'INFO',
+  target: 'user',
+  title: 'Resolved',
+  type: 'notification',
+  userId: '61730018ae92414d2bd15b4c',
+};
+
+describe('Default Notification Container', () => {
+  test('Render correctly', async () => {
+    render(
+      <PlatformNotifications notificationInfo={notificationsObj} readNotification={() => {}} />
+    );
+    expect(
+      screen.getByText(
+        'Outage description test for the following service(s): Boomerang Flow,Boomerang CICD'
+      )
+    ).toBeInTheDocument();
+  });
+});

--- a/src/components/PlatformNotifications/PlatformNotifications.spec.js
+++ b/src/components/PlatformNotifications/PlatformNotifications.spec.js
@@ -17,8 +17,8 @@ const notificationsObj = {
   userId: '61730018ae92414d2bd15b4c',
 };
 
-describe('Default Notification Container', () => {
-  test('Render correctly', async () => {
+describe('Platform notification', () => {
+  test('Renders correctly', async () => {
     render(
       <PlatformNotifications notificationInfo={notificationsObj} readNotification={() => {}} />
     );

--- a/src/components/PlatformNotifications/PlatformNotifications.stories.js
+++ b/src/components/PlatformNotifications/PlatformNotifications.stories.js
@@ -5,24 +5,31 @@ import { boolean } from '@storybook/addon-knobs';
 import PlatformNotificationsContainer from './index';
 
 // const mockSocketUrl = 'http://localhost:7750/notifications/ws';
-const mockSocketUrl = 'https://www.google.com/notifications/ws';
 
 export default {
   title: 'PlatformNotifications',
 };
+
+const mockSocketUrl = 'http://localhost:8080/ws';
 
 export const Default = () => {
   return (
     <PlatformNotificationsContainer
       initialNotifications={[
         {
-          id: 'testId',
-          creator: 'launchpad',
-          title: 'Maintenance Scheduled for a long long long long time',
+          creator: 'Boomerang CICD',
+          date: '2022-03-15T12:47:47.655+00:00',
           detail:
-            'Launchpad is scheduled for maintenance on January 8 from 2am-3am for a long long long time',
-          date: 1555079172156,
-          type: 'exception',
+            'Outage description test for the following service(s): Boomerang Flow,Boomerang CICD',
+          eventId: '620b9f7e99fcb715cbc222b3',
+          id: '620ba0f354f1b83f5077dec6',
+          priority: 'highest',
+          read: false,
+          severity: 'INFO',
+          target: 'user',
+          title: 'Resolved',
+          type: 'notification',
+          userId: '61730018ae92414d2bd15b4c',
         },
       ]}
       config={{

--- a/src/components/PlatformNotifications/PlatformNotificationsContainer-test.js
+++ b/src/components/PlatformNotifications/PlatformNotificationsContainer-test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render } from '@testing-library/react';
 import { action } from '@storybook/addon-actions';
 import axios from 'axios';
 import MockAdapter from 'axios-mock-adapter';
 import { Server } from 'mock-socket';
-import { getTime, subDays } from 'date-fns';
 
 import PlatformNotificationsContainer from './PlatformNotificationsContainer';
 
@@ -13,13 +12,18 @@ const mockServer = new Server(mockSocketUrl);
 const notificationsObj = {
   notifications: [
     {
-      id: 'testID1',
-      location: 'Launchpad',
-      title: 'Maintenance Scheduled for a long long long long time',
-      detail:
-        'Launchpad is scheduled for maintenance on January 8 from 2am-3am for a long long long time',
-      date: '1551300716020',
-      type: 'exception',
+      creator: 'Boomerang CICD',
+      date: '2022-02-15T12:47:47.655+00:00',
+      detail: 'Outage description test for the following service(s): Boomerang Flow,Boomerang CICD',
+      eventId: '620b9f7e99fcb715cbc222b3',
+      id: '620ba0f354f1b83f5077dec6',
+      priority: 'highest',
+      read: false,
+      severity: 'INFO',
+      target: 'user',
+      title: 'Resolved',
+      type: 'notification',
+      userId: '61730018ae92414d2bd15b4c',
     },
   ],
 };
@@ -32,9 +36,6 @@ mockServer.on('connection', (socket) => {
   socket.on('message', () => {
     setInterval(() => {
       notificationsObj.notifications[0].id = Math.round(Math.random() * 100000000); // Change for each one
-      notificationsObj.notifications[0].date = getTime(
-        subDays(new Date(), Math.round(Math.random() * 10))
-      );
       socket.send(JSON.stringify(notificationsObj));
     }, 10000);
   });
@@ -42,7 +43,7 @@ mockServer.on('connection', (socket) => {
 
 describe('Default Notification Container', () => {
   describe('Renders as expected', () => {
-    const wrapper = shallow(
+    const wrapper = render(
       <PlatformNotificationsContainer
         config={{
           wsUrl: 'ws://localhost:8081/ws',


### PR DESCRIPTION
## Context

Fix things with the date-fns function not accepting ISO date strings like before. 

Build Number:

2.0.1.rc.0

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If an item is not relevant to your change, you can put down "N/A" -->

- [x] Has been verified in an integrated environment
- [x] Has relevant unit and integration tests passing
- [x] Has no linting, test console, or browser console errors (best effort)
- [x] Has JSDoc comment blocks for complex code

## PR Review Guidance

<!--- Any guidance for reviewing this PR that is applicable either locally or in an integrated environment-->

## Additional Info

Update the story and added a test to make sure things render. That is part of why it wasn't caught before. Story data used a unix timestamp and there wasn't a test that covered the platform notifications being executed.  
