### PR TITLE
fix [ISEEC-4516] Issue 17 - UIShell menu items not showing active color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/carbon-addons-boomerang-react",
   "description": "Carbon Addons for Boomerang apps",
-  "version": "3.1.0",
+  "version": "3.1.1-beta.0",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -220,6 +220,10 @@
   &[aria-expanded="true"] {
     background: shell.$bmrg-header-menu-options-accent;
     border: utils.rem(2px) solid shell.$bmrg-header-menu-options-accent;
+
+    svg {
+      fill: shell.$bmrg-header-nav;
+    }
   }
 }
 

--- a/src/global/themes/_boomerang.scss
+++ b/src/global/themes/_boomerang.scss
@@ -165,7 +165,7 @@ $shell-tokens: (
   bmrg-header-active-background: #08bdba,
   bmrg-header-active-text: #f2f4f8,
   bmrg-header-hover-background: #343a3f,
-  bmrg-header-menu-options-accent: #343a3f,
+  bmrg-header-menu-options-accent: #08bdba,
   bmrg-header-menu-options-active-background: #002b50,
   bmrg-header-menu-options-top-border: #08bdba,
   bmrg-header-notification-default: #9fa5ad,

--- a/src/global/themes/_default.scss
+++ b/src/global/themes/_default.scss
@@ -10,7 +10,7 @@ $shell-tokens: (
   bmrg-header-active-background: #4589ff,
   bmrg-header-active-text: #f2f4f8,
   bmrg-header-hover-background: #343a3f,
-  bmrg-header-menu-options-accent: #262626,
+  bmrg-header-menu-options-accent: #4589ff,
   bmrg-header-menu-options-active-background: #262626,
   bmrg-header-menu-options-top-border: #4589ff,
   bmrg-header-notification-default: #9fa5ad,


### PR DESCRIPTION
## Context

Jira issue: ISEEC-4516

Version Number: 3.1.1-beta.0

## Checklist

- [x] Has been verified in an integrated environment
- [x] Has relevant unit and integration tests passing
- [x] Has no linting, test console, or browser console errors (best effort)
- [x] Has JSDoc comment blocks for complex code

## PR Review Guidance
- Check issue 17 of ISEEC-4516.
- The UIShell menu items should show the blue background when active.