### PR TITLE
fix: optmize render

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/carbon-addons-boomerang-react",
   "description": "Carbon Addons for Boomerang apps",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/src/components/AdvantageSideNav/AdvantageSideNav.tsx
+++ b/src/components/AdvantageSideNav/AdvantageSideNav.tsx
@@ -276,7 +276,7 @@ export function AdvantageSideNav(props: Props) {
                             </p>
                             {Boolean(team?.services?.length) ? <ChevronRight /> : null}
                           </SideNavLink>
-                          {Boolean(team?.services?.length) ?
+                          {Boolean(team?.services?.length) && team.id === activeSubmenu ?
                             <ul className={cx(`${prefix}--bmrg-advantage-sidenav-submenu`, {
                               "--open": team.id === activeSubmenu
                             })}
@@ -368,7 +368,7 @@ export function AdvantageSideNav(props: Props) {
                           </p>
                           {Boolean(team?.projectTeams?.length) ? <ChevronRight /> : null}
                         </SideNavLink>
-                        {Boolean(team?.projectTeams?.length) ? 
+                        {Boolean(team?.projectTeams?.length) && team.id === activeSubmenu ? 
                           <ul className={cx(`${prefix}--bmrg-advantage-sidenav-submenu`, {
                             "--open": team.id === activeSubmenu
                           })}


### PR DESCRIPTION
# PR Template  

Tag: 4.3.1

We've being discussing in the call earlier that the most probably reason is the UI not being able to render all the data. Before this update, the submenu with services and project teams were all being rendered at once. What I did was to add a condition to only render the list if some team is hovered

## Context

GitHub Issue:

Version Number:

## Checklist

- [ ] Has been verified in an integrated environment
- [ ] Has relevant unit and integration tests passing
- [ ] Has no linting, test console, or browser console errors (best effort)
- [ ] Has JSDoc comment blocks for complex code

## PR Review Guidance

## Additional Info