### PR TITLE
fix: hide overlay for sidenav in small resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/carbon-addons-boomerang-react",
   "description": "Carbon Addons for Boomerang apps",
-  "version": "4.4.9",
+  "version": "4.4.10",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/src/components/AdvantageSideNav/_advantageSideNav.scss
+++ b/src/components/AdvantageSideNav/_advantageSideNav.scss
@@ -9,8 +9,14 @@
   }
 }
 
-.#{$prefix}--side-nav__overlay-active{
+.#{$prefix}--side-nav__overlay-active {
   background-color: transparent;
+}
+
+@media (max-width: 65.98rem) {
+  .#{$prefix}--side-nav__overlay-active {
+    display: none;
+  }
 }
 
 .#{$prefix}--bmrg-advantage-sidenav-loading {


### PR DESCRIPTION
# PR Template  

Thanks for opening a PR!

## Context

GitHub Issue:
When navigating on Launchpad, AdvantageSideNav displays an overlay in smaller resolutions that blocks interactions with other components on screen. Removed this overlay.

Version Number:
4.4.10

## Checklist

- [ ] Has been verified in an integrated environment
- [ ] Has relevant unit and integration tests passing
- [ ] Has no linting, test console, or browser console errors (best effort)
- [ ] Has JSDoc comment blocks for complex code

## PR Review Guidance

## Additional Info