### PR TITLE
fix: test fix for icon color

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@boomerang-io/carbon-addons-boomerang-react",
   "description": "Carbon Addons for Boomerang apps",
-  "version": "4.5.9-beta.1",
+  "version": "4.5.9-beta.2",
   "author": {
     "name": "Tim Bula",
     "email": "timrbula@gmail.com"

--- a/src/components/Header/_header.scss
+++ b/src/components/Header/_header.scss
@@ -37,6 +37,15 @@ IBM Confidential
     }
 
     // Background overrides
+    .#{$prefix}--header__global {
+      .#{$prefix}--modal-close {
+        svg {
+          path {
+            fill: shell.$bmrg-theme-primary !important;
+          }
+        }
+      }
+    }
     .#{$prefix}--side-nav,
     .#{$prefix}--header-panel {
       background: shell.$bmrg-theme-background !important;


### PR DESCRIPTION
# PR Template  

Thanks for opening a PR!

## Context

GitHub Issue:
On white theme, modals on UIShell have the close icon button with the wrong color

Version Number:
4.5.9-beta.2

## Checklist

- [ ] Has been verified in an integrated environment
- [ ] Has relevant unit and integration tests passing
- [ ] Has no linting, test console, or browser console errors (best effort)
- [ ] Has JSDoc comment blocks for complex code

## PR Review Guidance

## Additional Info